### PR TITLE
feat: initialize Mirador viewer integration structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,12 @@ Pipfile
 Pipfile.lock
 pyproject.toml
 
+# IDE specific
+.vscode/
+*.code-workspace
+*.sublime-project
+*.sublime-workspace
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
@@ -63,3 +69,9 @@ target/
 
 # Vim swapfiles
 .*.sw?
+
+# macOS specific
+.DS_Store
+.AppleDouble
+.LSOverride
+._*


### PR DESCRIPTION
# Mirador IIIF Viewer Integration

## Changes
* Implements Mirador viewer as an Invenio previewer
* Sets up core module structure and configuration
* Adds viewer templates and integration logic
* Includes test infrastructure

## Testing
- [ ] Unit tests implemented
- [ ] Integration tests with IIIF resources
- [ ] Local deployment tested
- [ ] Test coverage maintained

## Documentation
- [ ] API documentation updated
- [ ] Configuration guide added
- [ ] Usage instructions included

## Acceptance Criteria
- [ ] Mirador successfully integrated as previewer
- [ ] IIIF-compatible resources display correctly
- [ ] All tests passing
- [ ] Documentation complete

Closes #1